### PR TITLE
fix: docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 services:
   streaming-server:
     build:
-      dockerfile: .
+      dockerfile: ./Dockerfile
       context: .
     container_name: nginx-rtmp-server
     volumes:


### PR DESCRIPTION
fix: failed to solve with frontend dockerfile.v0

Without fix:
```
root@s:/opt/weval-nginx-rtmp# docker compose up -d
[+] Building 0.0s (1/2)
 => [internal] load build definition from weval-nginx-rtmp                                                                                                                                                                               0.0s
 => => transferring dockerfile: 2.94kB                                                                                                                                                                                                   0.0s
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to read dockerfile: read /var/lib/docker/tmp/buildkit-mount1848879568/weval-nginx-rtmp: is a directory
root@s:/opt/weval-nginx-rtmp#
```